### PR TITLE
fix: ensure child node is a child of parent before removing

### DIFF
--- a/packages/@glimmer/runtime/lib/bounds.ts
+++ b/packages/@glimmer/runtime/lib/bounds.ts
@@ -65,7 +65,6 @@ export function move(bounds: Bounds, reference: Nullable<SimpleNode>): Nullable<
 }
 
 export function clear(bounds: Bounds): Nullable<SimpleNode> {
-  let parent = bounds.parentElement();
   let first = bounds.firstNode();
   let last = bounds.lastNode();
 
@@ -75,7 +74,7 @@ export function clear(bounds: Bounds): Nullable<SimpleNode> {
   while (true) {
     let next = current.nextSibling;
 
-    parent.removeChild(current);
+    current.parentNode?.removeChild(current);
 
     if (current === last) {
       return next;


### PR DESCRIPTION
Fixes GH-1401

If `current` isn't a child of `parent` calling `parent.removeChild(current)` will result in the error: `Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node`. This commonly occurs when the DOM is externally modified by a browser, such as when translating a page. The `nextSibling` may not be a child node of `parent`.

`current.parentNode?.removeChild(current)` ensures we are only removing a child node of a parent node.